### PR TITLE
Added How to start to Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Contributions, issues and feature requests are welcome!
 
 Feel free to check [issues page](https://github.com/lukaszbasaj/manual-javascript/issues). You can also take a look at the [contributing guide](https://github.com/lukaszbasaj/manual-javascript/blob/master/CONTRIBUTING.md).
 
+### How to start?
+
+Look for places that are sensitive to the expiration period by the new [ECMAScript](https://tc39.es/) version introduced.
+
+- [Lista słów zarezerwowanych](https://github.com/lukaszbasaj/manual-javascript/blob/master/data-types/variables.md#lista-s%C5%82%C3%B3w-zarezerwowanych)
 
 
 ## Author


### PR DESCRIPTION
I have the idea to add a section for some tips for new contributes to how to start. 

The first tip is relative to me yesterday PR about the [Updated Reserved Words](https://github.com/lukaszbasaj/manual-javascript/pull/16). Also, this tip and new tips could be will update when new changes are provided.

The next pro of this change is that we have one place which triggers updated after each new  [ECMAScript®](https://tc39.es/) version.